### PR TITLE
Fix vessel function implementation

### DIFF
--- a/src/ves_func.py
+++ b/src/ves_func.py
@@ -253,7 +253,10 @@ def analyze_vessel_mask(image_path, threshold=127, invert=False):
     junction_sizes = connected_component_sizes(junction_pixels)
     vessel_component_sizes = connected_component_sizes(mask)
 
-    vessel_density = float(mask.mean())
+    vessel_pixels = int(mask.sum())
+    total_pixels = int(mask.size)
+    vessel_density = vessel_pixels / total_pixels
+    vessel_density_percent = vessel_density * 100.0
     branch_count = len(branch_sizes)
     junction_count = len(junction_sizes)
     endpoint_count = int(endpoint_pixels.sum())
@@ -273,7 +276,10 @@ def analyze_vessel_mask(image_path, threshold=127, invert=False):
         "image_path": str(image_path),
         "width": int(width),
         "height": int(height),
+        "vessel_pixels": vessel_pixels,
+        "total_pixels": total_pixels,
         "vessel_density": vessel_density,
+        "vessel_density_percent": vessel_density_percent,
         "skeleton_pixels": int(skeleton.sum()),
         "branch_count": branch_count,
         "junction_count": junction_count,


### PR DESCRIPTION
This pull request enhances the vessel mask analysis in `src/ves_func.py` by providing more detailed output metrics related to vessel density. The main improvements include calculating and returning the absolute vessel pixel count, the total pixel count, and the vessel density as a percentage, in addition to the existing density metric.

**Vessel density metrics improvements:**

* The calculation of vessel density now explicitly computes the number of vessel pixels and the total number of pixels, and uses these to calculate both the density (as a ratio) and the density as a percentage.
* The results dictionary returned by `analyze_vessel_mask` now includes `vessel_pixels`, `total_pixels`, and `vessel_density_percent` fields, providing more granular information for downstream analysis or reporting.